### PR TITLE
Use native Polymer2 element as fallback for shadow dom

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ Polymer wrapper for Stripe.js v3 Elements. Creates a `card` element such as http
 
 ## :fire: Restrictions :fire:
 
-The stripe script doesn't work with ShadowDOM, so for now we have to force the ShadyDOM polyfill. Modify your webcomponentsjs include to match the following.
+The stripe script doesn't work with ShadowDOM, there are two options to work around it.
+
+### 1. Force ShadyDOM polyfill
+
+Modify your webcomponentsjs include to match the following.
 
 ```html
 <script>
@@ -16,6 +20,10 @@ The stripe script doesn't work with ShadowDOM, so for now we have to force the S
 </script>
 <script src="/bower_components/webcomponentsjs/webcomponents-loader.js"></script>
 ```
+
+### 2. Directly talk with the Stripe API
+
+You can enable a Polymer 2 replacement by setting `shadow-pci` on the Element. As the name suggests it might change your PCI Compliance Level (more infos needed).
 
 ## Usage
 <!--

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^2.0.0",
     "iron-icons": "PolymerElements/iron-icons#^2.0.0",
     "paper-button": "PolymerElements/paper-button#^2.0.0",
-    "paper-icon-button": "PolymerElements/paper-icon-button#^2.0.0"
+    "paper-icon-button": "PolymerElements/paper-icon-button#^2.0.0",
+    "stripe-shadow": "morbidick/stripe-elements#^2.1.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,11 @@
   "main": "stripe-elements.html",
   "dependencies": {
     "polymer": "Polymer/polymer#1.9 - 2",
-    "paper-toast": "PolymerElements/paper-toast#^2.0.0"
+    "paper-toast": "PolymerElements/paper-toast#^2.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^2.0.0",
+    "iron-icons": "PolymerElements/iron-icons#^2.0.0",
+    "paper-button": "PolymerElements/paper-button#^2.0.0",
+    "paper-icon-button": "PolymerElements/paper-icon-button#^2.0.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "iron-icons": "PolymerElements/iron-icons#^2.0.0",
     "paper-button": "PolymerElements/paper-button#^2.0.0",
     "paper-icon-button": "PolymerElements/paper-icon-button#^2.0.0",
-    "stripe-shadow": "morbidick/stripe-elements#^2.1.0"
+    "stripe-shadow": "morbidick/stripe-elements#^2.2.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -15,12 +15,12 @@
     "paper-icon-button": "PolymerElements/paper-icon-button#^2.0.0"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
+    "iron-component-page": "PolymerElements/iron-component-page#^2.0.0",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
     "web-component-tester": "^6.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
     "paper-input": "PolymerElements/paper-input#^2.0.0",
-    "show-json": "ryanburns23/show-json#^1.0.1"
+    "show-json": "ryanburns23/show-json#^2.0.0"
   },
   "resolutions": {
     "webcomponentsjs": "^1.0.0"

--- a/stripe-elements.html
+++ b/stripe-elements.html
@@ -130,6 +130,10 @@ When you apply CSS to the custom properties below, they're parsed and sent to St
         @apply --stripe-elements-element-webkit-autofill;
       }
 
+      stripe-card {
+        width: 100%;
+      }
+
       paper-toast {
         margin: 0;
       }
@@ -145,6 +149,7 @@ When you apply CSS to the custom properties below, they're parsed and sent to St
       <div id="card" aria-label="Credit or Debit Card">
         <!-- Stripe will inject form here -->
       </div>
+      <stripe-card id="shadowstripe" publishable-key="[[publishableKey]]" hide-zip="[[hidePostalCode]]" hide-submit></stripe-card>
 
       <paper-toast id="toast" text="[[error]]" duration="Infinity" opened="[[error]]">
         <paper-icon-button icon="close" on-tap="reset"></paper-icon-button>
@@ -240,6 +245,15 @@ When you apply CSS to the custom properties below, they're parsed and sent to St
           type: String,
         },
 
+        /**
+         * Whether to use stripe elements.js or the shadowDOM compatible version.
+         * Might influence your PCI compliance
+         */
+        shadowPci: {
+          type: Boolean,
+          value: false,
+        },
+
         _stripe: Object,
         _elements: Object,
         _card: Object,
@@ -274,14 +288,23 @@ When you apply CSS to the custom properties below, they're parsed and sent to St
        */
 
       ready: function() {
-        if (!window.Stripe) {
-          this._loadStripeJs();
+        if (this.shadowPci) {
+          if (!Polymer.Element) {
+            console.info('The Stripe shadowDOM version needs Polymer >2');
+          } else {
+            console.info('Using Stripe shadowDOM version');
+          }
+          this._loadStripeShadow();
         } else {
-          console.info('Stripe is available on window');
-        }
-        if (this.publishableKey) {
-          this._initStripe();
-          this._mountCard();
+          if (!window.Stripe) {
+            this._loadStripeJs();
+          } else {
+            console.info('Stripe is available on window');
+          }
+          if (this.publishableKey) {
+            this._initStripe();
+            this._mountCard();
+          }
         }
       },
 
@@ -326,6 +349,7 @@ When you apply CSS to the custom properties below, they're parsed and sent to St
        */
 
       _publishableKeyChanged: function(key, ov) {
+        if (this.shadowPci) { return; }
         if (!key) {return this._unmountCard();}
         this._unmountCard();
         this._stripe = {};
@@ -334,6 +358,7 @@ When you apply CSS to the custom properties below, they're parsed and sent to St
       },
 
       _styleChanged: function(style, ov) {
+        if (this.shadowPci) { return; }
         if (!style || ov === undefined) {return;}
         this._mountCard();
       },
@@ -361,6 +386,12 @@ When you apply CSS to the custom properties below, they're parsed and sent to St
         const loadAsync = false;
         this.importHref(stripeScript, onSuccess, onError, loadAsync);
         /* eslint-enable no-console */
+      },
+
+      _loadStripeShadow: function() {
+        const stripeElement = this.resolveUrl('../stripe-shadow/stripe-card.html');
+        this.importHref(stripeElement);
+        this._stripe = this.$.shadowstripe;
       },
 
       _initStripe: function() {

--- a/stripe-elements.html
+++ b/stripe-elements.html
@@ -149,7 +149,7 @@ When you apply CSS to the custom properties below, they're parsed and sent to St
       <div id="card" aria-label="Credit or Debit Card">
         <!-- Stripe will inject form here -->
       </div>
-      <stripe-card id="shadowstripe" publishable-key="[[publishableKey]]" hide-zip="[[hidePostalCode]]" hide-submit></stripe-card>
+      <stripe-card id="shadowstripe" publishable-key="[[publishableKey]]" hide-zip="[[hidePostalCode]]" hide-submit mask-card></stripe-card>
 
       <paper-toast id="toast" text="[[error]]" duration="Infinity" opened="[[error]]">
         <paper-icon-button icon="close" on-tap="reset"></paper-icon-button>

--- a/stripe-elements.html
+++ b/stripe-elements.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../paper-button/paper-button.html">
 <link rel="import" href="../paper-toast/paper-toast.html">
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">


### PR DESCRIPTION
I couldn't get the demo with data-binding working, seems to be a problem with version 2 of `iron-demo-helpers`.