### PR TITLE
reset error message after resolved

### DIFF
--- a/stripe-elements.html
+++ b/stripe-elements.html
@@ -308,6 +308,8 @@
       if (error) {
         this.$.toast.open();
         this.$.toast.positionTarget = this;
+      }else{
+        this.$.toast.close();
       }
     }
 
@@ -409,6 +411,10 @@
     onChange({empty, complete, brand, error, value} = {}) {
       if (error) {
         this._setError(error);
+      }
+
+      if (error === undefined && this.error !== undefined){
+        this._setError(undefined);
       }
     }
 

--- a/stripe-elements.html
+++ b/stripe-elements.html
@@ -308,7 +308,7 @@
       if (error) {
         this.$.toast.open();
         this.$.toast.positionTarget = this;
-      }else{
+      } else {
         this.$.toast.close();
       }
     }
@@ -413,7 +413,7 @@
         this._setError(error);
       }
 
-      if (error === undefined && this.error !== undefined){
+      if (error === undefined && this.error !== undefined) {
         this._setError(undefined);
       }
     }


### PR DESCRIPTION
When there's a validation error from Stripe, the toast opens and an error message appears but when the user corrects the error the message/toast don't disappear/close.