### PR TITLE
Allows card data to be sent with the token

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -44,6 +44,15 @@
                   padding: 1em;
                 }
 
+                .grid {
+                  display: flex;
+                  justify-content: space-between;
+                }
+
+                .grid .col {
+                  width: 32%;
+                }
+
               </style>
 
               <h2>Instructions</h2>
@@ -57,11 +66,47 @@
                   label="Input Stripe Publishable Key Here"
                   value="{{key}}"></paper-input>
 
+              <paper-input
+                  class="col"
+                  label="Cardholder Name"
+                  value="{{cardData.name::input}}"></paper-input>
+
+              <div class="grid">
+                <paper-input
+                  class="col"
+                  label="Cardholder Address Line1"
+                  value="{{cardData.address_line1::input}}"></paper-input>
+                <paper-input
+                    class="col"
+                    label="Cardholder Address Line2"
+                    value="{{cardData.address_line2::input}}"></paper-input>
+
+                <paper-input
+                    class="col"
+                    label="Cardholder Address City"
+                    value="{{cardData.address_city::input}}"></paper-input>
+              </div>
+              <div class="grid">
+                <paper-input
+                    class="col"
+                    label="Cardholder Address State"
+                    value="{{cardData.address_state::input}}"></paper-input>
+                <paper-input
+                    class="col"
+                    label="Cardholder Address Zip"
+                    value="{{cardData.address_zip::input}}"></paper-input>
+                <paper-input
+                    class="col"
+                    label="Cardholder Address Country"
+                    value="{{cardData.address_country::input}}"></paper-input>
+              </div>
+
               <div class="form">
 
                 <stripe-elements id="stripe"
                     stripe-ready="{{ready}}"
                     publishable-key="[[key]]"
+                    card-data="[[cardData]]"
                     token="{{token}}"></stripe-elements>
 
                 <paper-button id="button"
@@ -72,6 +117,19 @@
 
               <show-json hide-copy-button json="[[token]]"></show-json>
             </template>
+            <script>
+                var autobind = document.querySelector('dom-bind');
+                // set data property on dom-bind
+                autobind.cardData = {
+                  name: 'test name',
+                  address_line1: 'test line1',
+                  address_line2: '',
+                  address_city: '',
+                  address_state: '',
+                  address_zip: '',
+                  address_country: '',
+                };
+              </script>
           </dom-bind>
         </template>
       </demo-snippet>

--- a/demo/send_card_data.html
+++ b/demo/send_card_data.html
@@ -44,6 +44,15 @@
                   padding: 1em;
                 }
 
+                .grid {
+                  display: flex;
+                  justify-content: space-between;
+                }
+
+                .grid .col {
+                  width: 32%;
+                }
+
               </style>
 
               <h2>Instructions</h2>
@@ -57,11 +66,48 @@
                   label="Input Stripe Publishable Key Here"
                   value="{{key}}"></paper-input>
 
+              <paper-input
+                  class="col"
+                  label="Cardholder Name"
+                  value="{{cardData.name::input}}"></paper-input>
+
+              <div class="grid">
+                <paper-input
+                  class="col"
+                  label="Cardholder Address Line1"
+                  value="{{cardData.address_line1::input}}"></paper-input>
+                <paper-input
+                    class="col"
+                    label="Cardholder Address Line2"
+                    value="{{cardData.address_line2::input}}"></paper-input>
+
+                <paper-input
+                    class="col"
+                    label="Cardholder Address City"
+                    value="{{cardData.address_city::input}}"></paper-input>
+              </div>
+              <div class="grid">
+                <paper-input
+                    class="col"
+                    label="Cardholder Address State"
+                    value="{{cardData.address_state::input}}"></paper-input>
+                <paper-input
+                    class="col"
+                    label="Cardholder Address Zip"
+                    value="{{cardData.address_zip::input}}"></paper-input>
+                <paper-input
+                    class="col"
+                    label="Cardholder Address Country"
+                    value="{{cardData.address_country::input}}"></paper-input>
+              </div>
+
               <div class="form">
 
                 <stripe-elements id="stripe"
                     stripe-ready="{{ready}}"
                     publishable-key="[[key]]"
+                    card-data="[[cardData]]"
+                    hide-postal-code
                     token="{{token}}"></stripe-elements>
 
                 <paper-button id="button"
@@ -72,6 +118,19 @@
 
               <show-json hide-copy-button json="[[token]]"></show-json>
             </template>
+            <script>
+                var autobind = document.querySelector('dom-bind');
+                // set data property on dom-bind
+                autobind.cardData = {
+                  name: 'test name',
+                  address_line1: 'test line1',
+                  address_line2: '',
+                  address_city: '',
+                  address_state: '',
+                  address_zip: '',
+                  address_country: '',
+                };
+              </script>
           </dom-bind>
         </template>
       </demo-snippet>

--- a/stripe-elements.html
+++ b/stripe-elements.html
@@ -185,6 +185,15 @@
         },
 
         /**
+         * Card billing info to be passed to createToken() (optional)
+         * More information here https://stripe.com/docs/stripe-js/reference#stripe-create-token
+         * @type {Object}
+         */
+        cardData: {
+          type: Object,
+        },
+
+        /**
          * Permitted style names.
          * @type {Array}
          * @protected
@@ -513,7 +522,7 @@
      * @param  {Event} event Submit event.
      */
     submit(event) {
-      this.stripe.createToken(this.card)
+      this.stripe.createToken(this.card, this.cardData)
         .then(this.handleResponse.bind(this))
         .catch(this.handleError.bind(this));
     }


### PR DESCRIPTION
By passing the cardholder information into the `createToken()` method then if you want to retain the card in Stripe for further charging the cardholder data will already be there so you don't need to make a separate API call to update the card.