### PR TITLE
stripe-payment added as abstraction from #48

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -1,0 +1,2 @@
+// key should be here found in your stripe dashboard
+export const PUBLISHABLE_KEY="pk_test_PUTYOURKEYHERE";

--- a/demo/payment.html
+++ b/demo/payment.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <title>StripePayment: stripe-payment Demo</title>
+    <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="/node_modules/@lrnwebcomponents/deduping-fix/deduping-fix.js"></script>
+    <script src="/node_modules/web-animations-js/web-animations-next-lite.min.js"></script>
+    <script type="module">
+      import '/node_modules/@polymer/iron-demo-helpers/demo-snippet.js';
+      import '../src/stripe-payment.js';
+      import { PUBLISHABLE_KEY } from "./config.js";
+      window.PUBLISHABLE_KEY = PUBLISHABLE_KEY;
+    </script>
+  </head>
+  <body>
+    <div class="vertical-section-container centered">
+      <h3>Basic stripe-payment demo</h3>
+      <demo-snippet>
+        <template>
+          <stripe-payment id="payment"></stripe-payment>
+          <script src="https://js.stripe.com/v3/"></script>
+          <script defer="defer" async="async">
+            var payment = document.getElementById('payment');
+            // publishable key is imported from a config file
+            // and can be found in your Stripe account
+            payment.publishableKey = window.PUBLISHABLE_KEY;
+            payment.label = "Purchase";
+            payment.country = "US";
+            payment.currency = "usd";
+            payment.amount="100";
+            payment.debug = true;
+            payment.displayItems = [
+              { 
+                amount: 100,
+                label: "Unlimited futures"
+              },
+              { 
+                amount: 100,
+                label: "Other things"
+              }
+            ];
+            payment.shippingOptions = [
+              // The first shipping option in this list appears as the default
+              // option in the browser payment interface.
+              {
+                id: 'free-shipping',
+                label: 'Free slow shipping',
+                detail: 'Via email shortly after purchase',
+                amount: 0,
+              },
+              {
+                id: 'lots-to-ship',
+                label: 'Lots of ship',
+                detail: 'Things and stuff',
+                amount: 1000,
+              }
+            ];       
+          </script>
+        </template>
+      </demo-snippet>
+    </div>
+  </body>
+</html>

--- a/src/stripe-payment.js
+++ b/src/stripe-payment.js
@@ -1,0 +1,220 @@
+/**
+ * `stripe-payment`
+ * `Payment broker for stripe`
+ *
+ * @demo demo/index.html
+ * @customElement `stripe-payment`
+ */
+import { LitElement, html, css } from "lit-element/lit-element.js";
+import { ifDefined } from "lit-html/directives/if-defined.js";
+
+class StripePayment extends LitElement {
+  /**
+   * Convention
+   */
+  static get tag() {
+    return "stripe-payment";
+  }
+  /**
+   * LitElement render styles
+   */
+  static get styles() {
+    return [
+      css`
+        [hidden] {
+          display: none !important;
+        }
+        :host {
+          font-family: "Nunito Sans", -apple-system, ".SFNSText-Regular",
+            "San Francisco", BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
+            Helvetica, Arial, sans-serif;
+          align-items: center;
+          display: grid;
+          grid-gap: 12px;
+          grid-template-areas:
+            "support support"
+            "stripe submit"
+            "output output";
+        }
+        stripe-payment-request {
+          grid-area: submit/stripe/stripe/submit;
+        }
+        stripe-elements {
+          grid-area: stripe;
+        }
+        mwc-button {
+          grid-area: submit;
+        }
+        json-viewer {
+          grid-area: output;
+        }
+
+        stripe-elements:not(:defined),
+        json-viewer:not(:defined),
+        mwc-button:not(:defined) {
+          display: none;
+        }
+      `
+    ];
+  }
+  /**
+   * LitElement / popular convention
+   */
+  static get properties() {
+    return {
+      publishableKey: { type: String, attribute: "publishable-key" },
+      shippingOptions: { type: Array },
+      displayItems: { type: Array },
+      amount: { type: Number },
+      label: { type: String },
+      country: { type: String },
+      currency: { type: String },
+      paymentMethod: { type: Object },
+      error: { type: Object },
+      output: { type: Object },
+      unsupported: { type: Boolean },
+      submitDisabled: { type: Boolean },
+      paymentText: { type: String, attribute: "payment-text" },
+      debug: { type: Boolean }
+    };
+  }
+  /**
+   * HTMLElement
+   */
+  constructor() {
+    super();
+    this.submitDisabled = true;
+    this.debug = false;
+    this.displayItems = [];
+    this.shippingOptions = [];
+    this.amount = 0;
+    this.paymentText = "Submit";
+    this.label = "Purchase";
+    this.country = "US";
+    this.currency = "usd";
+    import("@power-elements/stripe-elements/stripe-payment-request.js");
+  }
+  /**
+   * LitElement render
+   */
+  render() {
+    return html`
+      <stripe-payment-request
+        ?hidden="${this.output || this.unsupported}"
+        publishable-key="${ifDefined(
+          this.publishableKey ? this.publishableKey : undefined
+        )}"
+        .shippingOptions="${this.shippingOptions}"
+        .displayItems="${this.displayItems}"
+        amount="${this.amount}"
+        label="${this.label}"
+        country="${this.country}"
+        currency="${this.currency}"
+        @payment-method="${this.onPaymentMethod}"
+        @error="${this.onError}"
+        @success="${this.onSuccess}"
+        @fail="${this.onFail}"
+        @ready="${this.onReady}"
+        @unsupported="${this.onUnsupported}"
+        generate="source"
+        request-payer-name
+        request-payer-email
+        request-payer-phone
+      >
+        ${this.displayItems.map(
+          item => html`
+            <stripe-display-item
+              data-amount="${item.amount}"
+              data-label="${item.label}"
+            ></stripe-display-item>
+          `
+        )}
+        ${this.shippingOptions.map(
+          ship => html`
+            <stripe-shipping-option
+              data-id="${ship.id}"
+              data-label="${ship.label}"
+              data-detail="${ship.detail}"
+              data-amount="${ship.amount}"
+            ></stripe-shipping-option>
+          `
+        )}
+      </stripe-payment-request>
+      ${this.debug
+        ? html`
+            <json-viewer
+              .object="${ifDefined(
+                this.error ? this.error : this.paymentMethod
+              )}"
+            ></json-viewer>
+          `
+        : ``}
+      ${this.unsupported
+        ? html`
+            <stripe-elements
+              ?hidden="${this.output || !this.unsupported}"
+              generate="source"
+              publishable-key="${ifDefined(
+                this.unsupported ? this.publishableKey : undefined
+              )}"
+              @change="${this.onChange}"
+              @source="${this.onSuccess}"
+              @error="${this.onError}"
+            >
+            </stripe-elements>
+            <mwc-button
+              tabindex="0"
+              ?hidden="${this.output || !this.unsupported}"
+              ?disabled="${this.submitDisabled}"
+              @click="${this.onClick}"
+              >${this.paymentText}</mwc-button
+            >
+          `
+        : ``}
+    `;
+  }
+  /**
+   * LitElement property change record
+   */
+  updated(changedProperties) {
+    changedProperties.forEach((oldvalue, propName) => {
+      if (propName == "debug" && this[propName]) {
+        // import json viewer if we are debugging
+        import("@power-elements/json-viewer/json-viewer.js");
+      }
+    });
+  }
+
+  onPaymentMethod({ detail: paymentMethod }) {
+    this.paymentMethod = paymentMethod;
+  }
+  onChange({ target: { complete, hasError } }) {
+    this.submitDisabled = !(complete && !hasError);
+  }
+  onError({ target: { error } }) {
+    this.error = error;
+    if (this.debug && this.error) {
+      console.error(error);
+    }
+  }
+  onClick() {
+    this.shadowRoot.querySelector("stripe-elements").submit();
+  }
+  onFail(event) {
+    this.output = event.detail;
+  }
+  onReady() {
+    this.unsupported = false;
+  }
+  onSuccess(event) {
+    this.output = event.detail;
+  }
+  onUnsupported() {
+    this.unsupported = true;
+    // import form when we fail our first check
+    import("@power-elements/stripe-elements/stripe-elements.js");
+    import("@material/mwc-button/mwc-button.js");
+  }
+}
+customElements.define(StripePayment.tag, StripePayment);
+export { StripePayment };


### PR DESCRIPTION
This adds a new element called `stripe-payment` built out of the example found in https://bennypowers.dev/stripe-elements/?path=/docs/fallback-to-stripe-elements--falling-back-to-stripe-elements-when-payment-request-is-not-supported

A demo is added as well which provides an example of how to put this element to use. Additional features added to this element:
- debug mode which imports `json-viewer` dynamically
- unsupported is used to rewrite the template and only import definitions for `mwc-button` and `stripe-elements`
- some additional visible text made into a variable as well as shipping and product options.

Not sure if you'll accept but I'm publishing as part of another organization so thank you for the direction :)