### PR TITLE
Support stripe connect

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ title: Stripe Elements Web Components
 publishableKey: pk_test_XXXXXXXXXXXXXXXXXXXXXXXX
 clientSecret: pk_test_XXXXXXXXXXXXXXXXXXXXXXXX
 parameters:
-  component: stripe-elements
+component: stripe-elements
 ---
 
 The `<stripe-elements>` custom element is an easy way to use stripe.js in your web app,
@@ -45,6 +45,8 @@ Enter a valid _testing_ publishable key in the input below to activate the examp
 > **Careful!** never add your **secret key** to an HTML page, only publish your **publishable key**.
 
 Once you've set the `publishable-key` attribute (or the `publishableKey` DOM property), Stripe will create a Stripe Card Element on your page.
+
+For use with Stripe Connect, you can provide the optional `stripe-account` attribute set to the account ID of the connected account.
 
 ### Accepting Payments
 
@@ -132,8 +134,8 @@ For simple integrations, you can automatically post the source or token to your 
 
 ```html
 <stripe-elements publishable-key="{{ publishableKey }}"
-    generate="token"
-    action="/my-endpoint"
+                 generate="token"
+                 action="/my-endpoint"
 ></stripe-elements>
 ```
 <iframe data-update="publishableKey" loading="lazy" src="{{ '/frames/elements/automatically-posting/' | url }}"></iframe>
@@ -171,13 +173,13 @@ for a purchase labelled "Double Double" that costs $1.25 Canadian, add this elem
 ```
 
 <stripe-payment-request
-    publishable-key="{{ publishableKey }}"
-    client-secret="{{ clientSecret }}"
-    generate="source"
-    amount="125"
-    label="Double Double"
-    country="CA"
-    currency="cad">
+publishable-key="{{ publishableKey }}"
+client-secret="{{ clientSecret }}"
+generate="source"
+amount="125"
+label="Double Double"
+country="CA"
+currency="cad">
 </stripe-payment-request>
 
 You can also display multiple line-items with the `<stripe-payment-item>` element:
@@ -225,13 +227,13 @@ You may also set the payment request options using JavaScript:
 const el = document.querySelector('stripe-payment-request');
 
 el.displayItems = [
-  { amount: '125', label: 'Double Double' },
-  { amount: '199', label: 'Box of 10 Timbits' },
+    { amount: '125', label: 'Double Double' },
+    { amount: '199', label: 'Box of 10 Timbits' },
 ]
 
 el.shippingOptions = [
-  { id: 'pick-up',  amount: 0,   label: 'Pick Up',  detail: "Pick Up at Your Local Timmy's" },
-  { id: 'delivery', amount: 200, label: 'Delivery', detail: 'Timbits to Your Door' }
+    { id: 'pick-up',  amount: 0,   label: 'Pick Up',  detail: "Pick Up at Your Local Timmy's" },
+    { id: 'delivery', amount: 200, label: 'Delivery', detail: 'Timbits to Your Door' }
 ]
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ title: Stripe Elements Web Components
 publishableKey: pk_test_XXXXXXXXXXXXXXXXXXXXXXXX
 clientSecret: pk_test_XXXXXXXXXXXXXXXXXXXXXXXX
 parameters:
-component: stripe-elements
+  component: stripe-elements
 ---
 
 The `<stripe-elements>` custom element is an easy way to use stripe.js in your web app,
@@ -134,8 +134,8 @@ For simple integrations, you can automatically post the source or token to your 
 
 ```html
 <stripe-elements publishable-key="{{ publishableKey }}"
-                 generate="token"
-                 action="/my-endpoint"
+    generate="token"
+    action="/my-endpoint"
 ></stripe-elements>
 ```
 <iframe data-update="publishableKey" loading="lazy" src="{{ '/frames/elements/automatically-posting/' | url }}"></iframe>
@@ -173,13 +173,13 @@ for a purchase labelled "Double Double" that costs $1.25 Canadian, add this elem
 ```
 
 <stripe-payment-request
-publishable-key="{{ publishableKey }}"
-client-secret="{{ clientSecret }}"
-generate="source"
-amount="125"
-label="Double Double"
-country="CA"
-currency="cad">
+    publishable-key="{{ publishableKey }}"
+    client-secret="{{ clientSecret }}"
+    generate="source"
+    amount="125"
+    label="Double Double"
+    country="CA"
+    currency="cad">
 </stripe-payment-request>
 
 You can also display multiple line-items with the `<stripe-payment-item>` element:
@@ -227,13 +227,13 @@ You may also set the payment request options using JavaScript:
 const el = document.querySelector('stripe-payment-request');
 
 el.displayItems = [
-    { amount: '125', label: 'Double Double' },
-    { amount: '199', label: 'Box of 10 Timbits' },
+  { amount: '125', label: 'Double Double' },
+  { amount: '199', label: 'Box of 10 Timbits' },
 ]
 
 el.shippingOptions = [
-    { id: 'pick-up',  amount: 0,   label: 'Pick Up',  detail: "Pick Up at Your Local Timmy's" },
-    { id: 'delivery', amount: 200, label: 'Delivery', detail: 'Timbits to Your Door' }
+  { id: 'pick-up',  amount: 0,   label: 'Pick Up',  detail: "Pick Up at Your Local Timmy's" },
+  { id: 'delivery', amount: 200, label: 'Delivery', detail: 'Timbits to Your Door' }
 ]
 ```
 

--- a/src/StripeBase.ts
+++ b/src/StripeBase.ts
@@ -139,6 +139,10 @@ export class StripeBase extends LitElement {
   @property({ type: Boolean, attribute: 'show-error', reflect: true })
   showError = false;
 
+  /** Stripe account to use (connect) */
+  @property({ type: String, attribute: 'stripe-account' })
+  stripeAccount: string;
+
   /* READ-ONLY FIELDS */
 
   /* PAYMENT REPRESENTATIONS */
@@ -388,13 +392,14 @@ export class StripeBase extends LitElement {
    * Initializes Stripe and elements.
    */
   private async initStripe(): Promise<void> {
-    const { publishableKey } = this;
+    const { publishableKey, stripeAccount } = this;
     if (!publishableKey)
       readonly.set<StripeBase>(this, { elements: null, element: null, stripe: null });
     else {
       try {
+        const options = stripeAccount ? { 'stripeAccount': stripeAccount } : {};
         const stripe =
-          (window.Stripe) ? window.Stripe(publishableKey) : await loadStripe(publishableKey);
+            (window.Stripe) ? window.Stripe(publishableKey, options) : await loadStripe(publishableKey, options);
         const elements = stripe?.elements();
         readonly.set<StripeBase>(this, { elements, error: null, stripe });
       } catch (e) {


### PR DESCRIPTION
The motivation behind this PR is to allow support for direct charges against connected accounts. To do this, we must pass in the stripeAccount attribute to the StripeConstructorOptions parameter when initialising stripe-js. 

This PR adds an additional, optional attribute `stripe-account`, allowing the user to provide the ID of the connected account they wish to make charges against.

This is supported both when initialising either via window.Stripe or loadStripe, both methods accept a StripeConstructorOptions parameter after publishableKey. This is where we set the stripe-account attribute that is passed to the web component.

See example of loading stripe elements with stripeAccount attribute:
https://stripe.com/docs/connect/creating-a-payments-page?platform=web&ui=elements#set-up-stripe-elements

When this value is set, the stripe library sets the `stripe-account` header on corresponding requests. It only needs to be set when we initialise stripe js, the rest is handled by stripe's library.