### PR TITLE
feature: add locale props for stripe initialization

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -321,9 +321,9 @@
               "kind": "field",
               "name": "locale",
               "type": {
-                "text": "StripeElementLocale"
+                "text": "Stripe.StripeElementLocale"
               },
-              "default": "null",
+              "default": "auto",
               "description": "Stripe locale to use (use browser locale by default)",
               "attribute": "locale",
               "reflects": true

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -318,6 +318,17 @@
               "reflects": true
             },
             {
+              "kind": "field",
+              "name": "locale",
+              "type": {
+                "text": "StripeElementLocale"
+              },
+              "default": "null",
+              "description": "Stripe locale to use (use browser locale by default)",
+              "attribute": "locale",
+              "reflects": true
+            },
+            {
               "kind": "method",
               "name": "createPaymentMethod",
               "privacy": "public",

--- a/src/StripeBase.ts
+++ b/src/StripeBase.ts
@@ -14,6 +14,7 @@ import { BreadcrumbController } from './breadcrumb-controller.js';
 import { readonly } from './lib/read-only.js';
 import { notify } from './lib/notify.js';
 import { loadStripe } from '@stripe/stripe-js/pure.js';
+import { StripeElementLocale } from '@stripe/stripe-js';
 
 export const enum SlotName {
   'stripe-elements' = 'stripe-elements-slot',
@@ -142,6 +143,10 @@ export class StripeBase extends LitElement {
   /** Stripe account to use (connect) */
   @property({ type: String, attribute: 'stripe-account' })
   stripeAccount: string;
+
+  /** Stripe locale to use */
+  @property({ type: String, attribute: 'locale' })
+    locale: StripeElementLocale;
 
   /* READ-ONLY FIELDS */
 
@@ -392,12 +397,12 @@ export class StripeBase extends LitElement {
    * Initializes Stripe and elements.
    */
   private async initStripe(): Promise<void> {
-    const { publishableKey, stripeAccount } = this;
+    const { publishableKey, stripeAccount, locale } = this;
     if (!publishableKey)
       readonly.set<StripeBase>(this, { elements: null, element: null, stripe: null });
     else {
       try {
-        const options = { stripeAccount };
+        const options = { stripeAccount, locale };
         const stripe =
           (window.Stripe) ? window.Stripe(publishableKey, options) : await loadStripe(publishableKey, options);
         const elements = stripe?.elements();

--- a/src/StripeBase.ts
+++ b/src/StripeBase.ts
@@ -146,7 +146,7 @@ export class StripeBase extends LitElement {
 
   /** Stripe locale to use */
   @property({ type: String, attribute: 'locale' })
-    locale: StripeElementLocale;
+    locale: StripeElementLocale = 'auto';
 
   /* READ-ONLY FIELDS */
 

--- a/test/stripe-elements.test.ts
+++ b/test/stripe-elements.test.ts
@@ -920,6 +920,20 @@ describe('<stripe-elements>', function() {
             });
           });
         });
+
+        describe('with no `locale` property set', function() {
+          it('should have `auto` by default', function() {
+            expect(element.locale).to.be.equal('auto');
+          });
+        });
+
+        describe('with `locale` property set', function() {
+          const LOCALE = 'en';
+          beforeEach(Helpers.setProps({ locale: LOCALE }));
+          it(`should have ${LOCALE}`, function() {
+            expect(element.locale).to.be.equal('en');
+          });
+        });
       });
 
       describe('with a card that will be declined', function() {

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -135,6 +135,7 @@ export const BASE_DEFAULT_PROPS = Object.freeze({
   source: null,
   stripe: null,
   token: null,
+  locale: 'auto',
 });
 
 export const BASE_READ_ONLY_PROPS = Object.freeze([


### PR DESCRIPTION
This PR adds possibility to pass a props called locale which allow to define the language showed inside stripe elements.